### PR TITLE
Remove Delete*Key* permissions from admin user

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -115,8 +115,7 @@ resource "aws_kms_key" "kms_key" {
         "kms:Revoke*",
         "kms:Disable*",
         "kms:Get*",
-        "kms:Delete*",
-        "kms:ScheduleKeyDeletion",
+        "kms:DeleteAlias",
         "kms:CancelKeyDeletion"
       ],
       "Resource": "*"


### PR DESCRIPTION
Prior to this change, the admin had the power to delete keys and
rendering the data encrypted with the keys unrecoverable.  It turns out
that admin users can't even be trusted with this power.

This change removes all the delete permissions except for DeleteAlias.